### PR TITLE
More Linting (fixes #11)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+bootstrap.js
+stub-content/index.js

--- a/data/message-bridge.js
+++ b/data/message-bridge.js
@@ -1,11 +1,11 @@
 // Page script acts as messaging bridge between addon and web content.
 
-window.addEventListener("from-web-to-addon", function (event) {
+window.addEventListener('from-web-to-addon', function(event) {
   self.port.emit('from-web-to-addon', event.detail);
 }, false);
 
-self.port.on('from-addon-to-web', function (data) {
-  var clonedDetail = cloneInto(data, document.defaultView);
+self.port.on('from-addon-to-web', function(data) {
+  const clonedDetail = cloneInto(data, document.defaultView);
   document.documentElement.dispatchEvent(new CustomEvent(
     'from-addon-to-web', { bubbles: true, detail: clonedDetail }
   ));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "st -nc .",
-    "lint": "eslint index.js",
+    "lint": "eslint .",
     "package": "jpm xpi && mv @idea-town-addon-0.0.1.xpi dist/idea-town-addon-0.0.1.xpi"
   },
   "license": "MPL-2.0",

--- a/stub-content/index.js
+++ b/stub-content/index.js
@@ -4,10 +4,9 @@ function statusUpdate(msg, detail) {
   var p = document.createElement('p');
   p.textContent = msg;
   statusBox.appendChild(p);
-  console.log('STATUS UPDATE:: ', msg, ' :: ', detail);
 }
 
-window.addEventListener("from-addon-to-web", function (event) {
+window.addEventListener('from-addon-to-web', function(event) {
   if (!event.detail || !event.detail.type) { return; }
   statusUpdate(event.detail.type, event.detail);
   switch (event.detail.type) {
@@ -58,7 +57,7 @@ function renderUpdates(ev) {
 document.querySelector('.update-submit').onclick = function(ev) {
   var approvedUpdates = Array.slice.call(0, document.querySelectorAll('.updates li')).filter(function(el) {
                           return (el.querySelector('input').checked);
-  }).map(function(el) {return el.textContent});
+  }).map(function(el) {return el.textContent;});
 
   sendToAddon({type: 'update-approve', detail: approvedUpdates});
-}
+};

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,12 +1,12 @@
-var main = require("../");
+// const main = require('../');
 
-exports["test main"] = function(assert) {
-  assert.pass("Unit test running!");
+exports['test main'] = function(assert) {
+  assert.pass('Unit test running!');
 };
 
-exports["test main async"] = function(assert, done) {
-  assert.pass("async Unit test running!");
+exports['test main async'] = function(assert, done) {
+  assert.pass('async Unit test running!');
   done();
 };
 
-require("sdk/test").run(exports);
+require('sdk/test').run(exports);


### PR DESCRIPTION
 fixes #11 
ignored both `bootstrap.js` and `stub-content/index.js` since browsers still do not fully support `const` and `let`. I figured we do not want to add a babel test for our testing/example file.