### PR TITLE
Attach page-mod to existing pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const mod = new PageMod({
   include: prefs.ALLOWED_ORIGINS.split(','),
   contentScriptFile: self.data.url('message-bridge.js'),
   contentScriptWhen: 'start',
+  attachTo: ['top', 'existing'],
   onAttach: setupApp
 });
 


### PR DESCRIPTION
By attaching the page-mod scripts to existing pages, a user with the website open, who finishes the addon install process, will actually see the page update itself. Without this patch, they'd need to manually refresh the page to see the logged-in view.

@lmorchard @meandavejustice r?