### PR TITLE
Notify the front-end when the addon is uninstalled

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const mod = new PageMod({
 
 require('sdk/system/unload').when(function(reason) {
   if (reason === 'uninstall') {
+    app.send('addon-self:uninstalled');
     if (store.experiments) {
       uninstall(store.experiments);
       delete store.experiments;


### PR DESCRIPTION
We currently send an `addon-self:installed` signal, but don't send a parallel signal when the addon is uninstalled.

This patch adds the uninstall signal.

We'll eventually have the addon tell the server, and the server tell the front-end, that the addon has been uninstalled, but this works for now, and makes the event API more symmetric, which is also nice.

@lmorchard @meandavejustice r?